### PR TITLE
shouldn't chain dig methods

### DIFF
--- a/lib/awesome_explain/command_subscriber.rb
+++ b/lib/awesome_explain/command_subscriber.rb
@@ -62,7 +62,7 @@ module AwesomeExplain
           command: command.include?('pipeline') ? command['pipeline'] : command.select {|k, v| COMMAND_ALLOWED_KEYS.include?(k)},
           collection_name: collection_name,
           stacktrace: caller,
-          lsid: command.dig('lsid').dig('id').to_json
+          lsid: command.dig('lsid', 'id').to_json
         }.with_indifferent_access
 
         unless DML_COMMANDS.include?(command_name) || Rails.const_defined?('Console') || command_name == :getMore


### PR DESCRIPTION
resulted in the error 

```
NoMethodError (undefined method `dig' for nil:NilClass):
```